### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ This is a TypeScript-based MCP server that implements a simple notes system. It 
 - Tools for creating new notes
 - Prompts for generating summaries of notes
 
+<a href="https://glama.ai/mcp/servers/@Spritualkb/nuclei-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@Spritualkb/nuclei-mcp/badge" alt="nuclei-server Server MCP server" />
+</a>
+
 ## Features
 
 ### Resources


### PR DESCRIPTION
This PR adds a badge for the [nuclei-server MCP Server](https://glama.ai/mcp/servers/@Spritualkb/nuclei-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@Spritualkb/nuclei-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@Spritualkb/nuclei-mcp/badge" alt="nuclei-server Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.